### PR TITLE
Update Arduino.java

### DIFF
--- a/arduino/src/main/java/me/aflak/arduino/Arduino.java
+++ b/arduino/src/main/java/me/aflak/arduino/Arduino.java
@@ -224,6 +224,9 @@ public class Arduino implements UsbSerialInterface.UsbReadCallback {
             } else{
                 int offset = 0;
                 for(int index : idx){
+                    if (index < offset) {
+                        continue;
+                    }
                     byte[] tmp = Arrays.copyOfRange(bytes, offset, index);
                     bytesReceived.addAll(toByteList(tmp));
                     if(listener != null) {


### PR DESCRIPTION
```
Arrays.copyOfRange(bytes, offset, index);
```
throws exception if index is less than offset. I don't know why index is less than offset in the first place (for my project it randomly happened). This is working workaround.