### PR TITLE
Fix #23 pending mutability issue on android 12+ & add missing ContextCompat.RECEIVER_EXPORTED for broadcast receivers

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,7 +4,7 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="testRunner" value="PLATFORM" />
+        <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="modules">
@@ -14,8 +14,6 @@
             <option value="$PROJECT_DIR$/arduino" />
           </set>
         </option>
-        <option name="resolveModulePerSourceSet" value="false" />
-        <option name="useQualifiedModuleNames" value="true" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,10 +4,8 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="testRunner" value="GRADLE" />
-        <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="11" />
+        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
@@ -15,6 +13,7 @@
             <option value="$PROJECT_DIR$/arduino" />
           </set>
         </option>
+        <option name="resolveExternalAnnotations" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="corretto-1.8" project-jdk-type="JavaSDK" />
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="corretto-1.8" project-jdk-type="JavaSDK" />
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="corretto-11" project-jdk-type="JavaSDK" />
 </project>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId "me.aflak.libraries"
         minSdkVersion 15
         targetSdkVersion 31
-        versionCode 2
-        versionName "3.0"
+        versionCode 3
+        versionName "1.5.1"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ android {
         minSdkVersion 15
         targetSdkVersion 31
         versionCode 2
-        versionName "2.0"
+        versionName "3.0"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     defaultConfig {
         applicationId "me.aflak.libraries"
         minSdkVersion 15
-        targetSdkVersion 30
-        versionCode 1
-        versionName "1.0"
+        targetSdkVersion 31
+        versionCode 2
+        versionName "2.0"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     defaultConfig {
         applicationId "me.aflak.libraries"
         minSdkVersion 15
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 2
         versionName "1.0"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
@@ -27,7 +27,7 @@ dependencies {
     androidTestImplementation('androidx.test.espresso:espresso-core:3.1.0', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation project(path: ':arduino')
 }

--- a/arduino/build.gradle
+++ b/arduino/build.gradle
@@ -13,7 +13,7 @@ ext {
     siteUrl = 'https://github.com/omaflak/Arduino'
     gitUrl = 'https://github.com/omaflak/Arduino.git'
 
-    libraryVersion = '1.4.5'
+    libraryVersion = '1.4.6'
 
     developerId = 'omaflak'
     developerName = 'Omar Aflak'
@@ -25,13 +25,13 @@ ext {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 30
-        versionCode 8
-        versionName "1.4.5"
+        targetSdkVersion 31
+        versionCode 9
+        versionName "1.4.6"
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
 

--- a/arduino/build.gradle
+++ b/arduino/build.gradle
@@ -13,7 +13,7 @@ ext {
     siteUrl = 'https://github.com/omaflak/Arduino'
     gitUrl = 'https://github.com/omaflak/Arduino.git'
 
-    libraryVersion = '1.4.6'
+    libraryVersion = '1.5.0'
 
     developerId = 'omaflak'
     developerName = 'Omar Aflak'
@@ -31,7 +31,7 @@ android {
         minSdkVersion 15
         targetSdkVersion 31
         versionCode 9
-        versionName "1.4.6"
+        versionName "1.5.0"
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
 

--- a/arduino/build.gradle
+++ b/arduino/build.gradle
@@ -31,7 +31,7 @@ android {
         minSdkVersion 15
         targetSdkVersion 31
         versionCode 9
-        versionName "1.5.0"
+        versionName "1.5.1"
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
 

--- a/arduino/build.gradle
+++ b/arduino/build.gradle
@@ -13,7 +13,7 @@ ext {
     siteUrl = 'https://github.com/omaflak/Arduino'
     gitUrl = 'https://github.com/omaflak/Arduino.git'
 
-    libraryVersion = '1.5.0'
+    libraryVersion = '1.6.1'
 
     developerId = 'omaflak'
     developerName = 'Omar Aflak'
@@ -31,7 +31,7 @@ android {
         minSdkVersion 15
         targetSdkVersion 31
         versionCode 9
-        versionName "1.5.1"
+        versionName "1.6.1"
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
 

--- a/arduino/build.gradle
+++ b/arduino/build.gradle
@@ -25,11 +25,11 @@ ext {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 9
         versionName "1.4.6"
 
@@ -49,7 +49,7 @@ dependencies {
     androidTestImplementation('androidx.test.espresso:espresso-core:3.1.0', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
 
     api 'com.github.felHR85:UsbSerial:6.1.0'
 }

--- a/arduino/src/main/java/me/aflak/arduino/Arduino.java
+++ b/arduino/src/main/java/me/aflak/arduino/Arduino.java
@@ -82,7 +82,7 @@ public class Arduino implements UsbSerialInterface.UsbReadCallback {
     }
 
     public void open(UsbDevice device) {
-        PendingIntent permissionIntent = PendingIntent.getBroadcast(context, 0, new Intent(ACTION_USB_DEVICE_PERMISSION), PendingIntent.FLAG_IMMUTABLE);
+        PendingIntent permissionIntent = PendingIntent.getBroadcast(context, 0, new Intent(ACTION_USB_DEVICE_PERMISSION), PendingIntent.FLAG_UPDATE_CURRENT );
         IntentFilter filter = new IntentFilter();
         filter.addAction(ACTION_USB_DEVICE_PERMISSION);
         filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);

--- a/arduino/src/main/java/me/aflak/arduino/Arduino.java
+++ b/arduino/src/main/java/me/aflak/arduino/Arduino.java
@@ -82,7 +82,7 @@ public class Arduino implements UsbSerialInterface.UsbReadCallback {
     }
 
     public void open(UsbDevice device) {
-        PendingIntent permissionIntent = PendingIntent.getBroadcast(context, 0, new Intent(ACTION_USB_DEVICE_PERMISSION), PendingIntent.FLAG_MUTABLE);
+        PendingIntent permissionIntent = PendingIntent.getBroadcast(context, 0, new Intent(ACTION_USB_DEVICE_PERMISSION), PendingIntent.FLAG_IMMUTABLE);
         IntentFilter filter = new IntentFilter();
         filter.addAction(ACTION_USB_DEVICE_PERMISSION);
         filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);

--- a/arduino/src/main/java/me/aflak/arduino/Arduino.java
+++ b/arduino/src/main/java/me/aflak/arduino/Arduino.java
@@ -82,7 +82,7 @@ public class Arduino implements UsbSerialInterface.UsbReadCallback {
     }
 
     public void open(UsbDevice device) {
-        PendingIntent permissionIntent = PendingIntent.getBroadcast(context, 0, new Intent(ACTION_USB_DEVICE_PERMISSION), 0);
+        PendingIntent permissionIntent = PendingIntent.getBroadcast(context, 0, new Intent(ACTION_USB_DEVICE_PERMISSION), PendingIntent.FLAG_MUTABLE);
         IntentFilter filter = new IntentFilter();
         filter.addAction(ACTION_USB_DEVICE_PERMISSION);
         filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);

--- a/arduino/src/main/java/me/aflak/arduino/Arduino.java
+++ b/arduino/src/main/java/me/aflak/arduino/Arduino.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Created by Omar on 21/05/2017.
@@ -34,7 +35,7 @@ public class Arduino implements UsbSerialInterface.UsbReadCallback {
 
     private int baudRate;
     private boolean isOpened;
-    private List<Integer> vendorIds;
+    private List<String> vendorIds;
     private List<Byte> bytesReceived;
     private byte delimiter;
 
@@ -57,7 +58,14 @@ public class Arduino implements UsbSerialInterface.UsbReadCallback {
         this.baudRate = baudRate;
         this.isOpened = false;
         this.vendorIds = new ArrayList<>();
-        this.vendorIds.add(9025);
+        this.vendorIds.add("9025");
+        this.vendorIds.add("1027");
+        this.vendorIds.add("5824");
+        this.vendorIds.add("4292");
+        this.vendorIds.add("1659");
+        this.vendorIds.add("4966");
+        this.vendorIds.add("1A86");
+
         this.bytesReceived = new ArrayList<>();
         this.delimiter = DEFAULT_DELIMITER;
     }
@@ -82,7 +90,7 @@ public class Arduino implements UsbSerialInterface.UsbReadCallback {
     }
 
     public void open(UsbDevice device) {
-        PendingIntent permissionIntent = PendingIntent.getBroadcast(context, 0, new Intent(ACTION_USB_DEVICE_PERMISSION), PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT );
+        PendingIntent permissionIntent = PendingIntent.getBroadcast(context, 0, new Intent(ACTION_USB_DEVICE_PERMISSION), PendingIntent.FLAG_MUTABLE );
         IntentFilter filter = new IntentFilter();
         filter.addAction(ACTION_USB_DEVICE_PERMISSION);
         filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);
@@ -112,15 +120,15 @@ public class Arduino implements UsbSerialInterface.UsbReadCallback {
         }
     }
 
-    public void setDelimiter(byte delimiter){
+    public void setDelimiter(byte delimiter) {
         this.delimiter = delimiter;
     }
 
-    public void setBaudRate(int baudRate){
+    public void setBaudRate(int baudRate) {
         this.baudRate = baudRate;
     }
 
-    public void addVendorId(int id){
+    public void addVendorId(String id) {
         vendorIds.add(id);
     }
 
@@ -132,7 +140,7 @@ public class Arduino implements UsbSerialInterface.UsbReadCallback {
                 switch (intent.getAction()) {
                     case UsbManager.ACTION_USB_DEVICE_ATTACHED:
                         device = intent.getParcelableExtra(UsbManager.EXTRA_DEVICE);
-                        if (hasId(device.getVendorId())) {
+                        if (hasId(String.valueOf(device.getVendorId()))) {
                             lastArduinoAttached = device;
                             if (listener != null) {
                                 listener.onArduinoAttached(device);
@@ -141,7 +149,7 @@ public class Arduino implements UsbSerialInterface.UsbReadCallback {
                         break;
                     case UsbManager.ACTION_USB_DEVICE_DETACHED:
                         device = intent.getParcelableExtra(UsbManager.EXTRA_DEVICE);
-                        if (hasId(device.getVendorId())) {
+                        if (hasId(String.valueOf(device.getVendorId()))) {
                             if (listener != null) {
                                 listener.onArduinoDetached();
                             }
@@ -150,7 +158,7 @@ public class Arduino implements UsbSerialInterface.UsbReadCallback {
                     case ACTION_USB_DEVICE_PERMISSION:
                         if (intent.getBooleanExtra(UsbManager.EXTRA_PERMISSION_GRANTED, false)) {
                             device = intent.getParcelableExtra(UsbManager.EXTRA_DEVICE);
-                            if (hasId(device.getVendorId())) {
+                            if (hasId(String.valueOf(device.getVendorId()))) {
                                 connection = usbManager.openDevice(device);
                                 serialPort = UsbSerialDevice.createUsbSerialDevice(device, connection);
                                 if (serialPort != null) {
@@ -182,34 +190,34 @@ public class Arduino implements UsbSerialInterface.UsbReadCallback {
     private UsbDevice getAttachedArduino() {
         HashMap<String, UsbDevice> map = usbManager.getDeviceList();
         for (UsbDevice device : map.values()) {
-            if (hasId(device.getVendorId())) {
+            if (hasId(String.valueOf(device.getVendorId()))) {
                 return device;
             }
         }
         return null;
     }
 
-    private List<Integer> indexOf(byte[] bytes, byte b){
+    private List<Integer> indexOf(byte[] bytes, byte b) {
         List<Integer> idx = new ArrayList<>();
-        for(int i=0 ; i<bytes.length ; i++){
-            if(bytes[i] == b){
+        for (int i = 0; i < bytes.length; i++) {
+            if (bytes[i] == b) {
                 idx.add(i);
             }
         }
         return idx;
     }
 
-    private List<Byte> toByteList(byte[] bytes){
+    private List<Byte> toByteList(byte[] bytes) {
         List<Byte> list = new ArrayList<>();
-        for(byte b : bytes){
+        for (byte b : bytes) {
             list.add(b);
         }
         return list;
     }
 
-    private byte[] toByteArray(List<Byte> bytes){
+    private byte[] toByteArray(List<Byte> bytes) {
         byte[] array = new byte[bytes.size()];
-        for(int i=0 ; i<bytes.size() ; i++){
+        for (int i = 0; i < bytes.size(); i++) {
             array[i] = bytes.get(i);
         }
         return array;
@@ -219,21 +227,21 @@ public class Arduino implements UsbSerialInterface.UsbReadCallback {
     public void onReceivedData(byte[] bytes) {
         if (bytes.length != 0) {
             List<Integer> idx = indexOf(bytes, delimiter);
-            if(idx.isEmpty()){
+            if (idx.isEmpty()) {
                 bytesReceived.addAll(toByteList(bytes));
-            } else{
+            } else {
                 int offset = 0;
-                for(int index : idx){
+                for (int index : idx) {
                     byte[] tmp = Arrays.copyOfRange(bytes, offset, index);
                     bytesReceived.addAll(toByteList(tmp));
-                    if(listener != null) {
+                    if (listener != null) {
                         listener.onArduinoMessage(toByteArray(bytesReceived));
                     }
                     bytesReceived.clear();
                     offset = index + 1;
                 }
 
-                if(offset < bytes.length){
+                if (offset < bytes.length) {
                     byte[] tmp = Arrays.copyOfRange(bytes, offset, bytes.length);
                     bytesReceived.addAll(toByteList(tmp));
                 }
@@ -245,10 +253,10 @@ public class Arduino implements UsbSerialInterface.UsbReadCallback {
         return isOpened;
     }
 
-    private boolean hasId(int id) {
-        Log.i(getClass().getSimpleName(), "Vendor id : "+id);
-        for(int vendorId : vendorIds){
-            if(vendorId==id){
+    private boolean hasId(String id) {
+        Log.i(getClass().getSimpleName(), "Vendor id : " + id);
+        for (String vendorId : vendorIds) {
+            if (Objects.equals(vendorId, id)) {
                 return true;
             }
         }

--- a/arduino/src/main/java/me/aflak/arduino/Arduino.java
+++ b/arduino/src/main/java/me/aflak/arduino/Arduino.java
@@ -82,7 +82,7 @@ public class Arduino implements UsbSerialInterface.UsbReadCallback {
     }
 
     public void open(UsbDevice device) {
-        PendingIntent permissionIntent = PendingIntent.getBroadcast(context, 0, new Intent(ACTION_USB_DEVICE_PERMISSION), PendingIntent.FLAG_UPDATE_CURRENT );
+        PendingIntent permissionIntent = PendingIntent.getBroadcast(context, 0, new Intent(ACTION_USB_DEVICE_PERMISSION), PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT );
         IntentFilter filter = new IntentFilter();
         filter.addAction(ACTION_USB_DEVICE_PERMISSION);
         filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);

--- a/arduino/src/main/java/me/aflak/arduino/Arduino.java
+++ b/arduino/src/main/java/me/aflak/arduino/Arduino.java
@@ -96,7 +96,7 @@ public class Arduino implements UsbSerialInterface.UsbReadCallback {
 
     @SuppressLint("NewApi")
     public void open(UsbDevice device) {
-        PendingIntent permissionIntent = PendingIntent.getBroadcast(context, 0, new Intent(ACTION_USB_DEVICE_PERMISSION), PendingIntent.FLAG_MUTABLE);
+        PendingIntent permissionIntent = PendingIntent.getBroadcast(context, 0, new Intent(ACTION_USB_DEVICE_PERMISSION), PendingIntent.FLAG_IMMUTABLE);
         IntentFilter filter = new IntentFilter();
         filter.addAction(ACTION_USB_DEVICE_PERMISSION);
         filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);

--- a/arduino/src/main/java/me/aflak/arduino/Arduino.java
+++ b/arduino/src/main/java/me/aflak/arduino/Arduino.java
@@ -1,5 +1,6 @@
 package me.aflak.arduino;
 
+import android.annotation.SuppressLint;
 import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -8,7 +9,9 @@ import android.content.IntentFilter;
 import android.hardware.usb.UsbDevice;
 import android.hardware.usb.UsbDeviceConnection;
 import android.hardware.usb.UsbManager;
+import android.os.Build;
 import android.util.Log;
+
 import androidx.core.content.ContextCompat;
 
 import com.felhr.usbserial.UsbSerialDevice;
@@ -71,6 +74,7 @@ public class Arduino implements UsbSerialInterface.UsbReadCallback {
         this.delimiter = DEFAULT_DELIMITER;
     }
 
+    @SuppressLint("NewApi")
     public void setArduinoListener(ArduinoListener listener) {
         this.listener = listener;
 
@@ -78,7 +82,7 @@ public class Arduino implements UsbSerialInterface.UsbReadCallback {
         intentFilter.addAction(UsbManager.ACTION_USB_DEVICE_ATTACHED);
         intentFilter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);
         intentFilter.addAction(ACTION_USB_DEVICE_PERMISSION);
-        context.registerReceiver(usbReceiver, intentFilter,ContextCompat.RECEIVER_EXPORTED);
+        context.registerReceiver(usbReceiver, intentFilter, Context.RECEIVER_EXPORTED);
 
         lastArduinoAttached = getAttachedArduino();
         if (lastArduinoAttached != null && listener != null) {
@@ -90,12 +94,13 @@ public class Arduino implements UsbSerialInterface.UsbReadCallback {
         this.listener = null;
     }
 
+    @SuppressLint("NewApi")
     public void open(UsbDevice device) {
-        PendingIntent permissionIntent = PendingIntent.getBroadcast(context, 0, new Intent(ACTION_USB_DEVICE_PERMISSION), PendingIntent.FLAG_MUTABLE);
+        PendingIntent permissionIntent = PendingIntent.getBroadcast(context, 0, new Intent(ACTION_USB_DEVICE_PERMISSION), PendingIntent.FLAG_IMMUTABLE);
         IntentFilter filter = new IntentFilter();
         filter.addAction(ACTION_USB_DEVICE_PERMISSION);
         filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);
-        context.registerReceiver(usbReceiver, filter,ContextCompat.RECEIVER_EXPORTED);
+        context.registerReceiver(usbReceiver, filter, Context.RECEIVER_EXPORTED);
         usbManager.requestPermission(device, permissionIntent);
     }
 

--- a/arduino/src/main/java/me/aflak/arduino/Arduino.java
+++ b/arduino/src/main/java/me/aflak/arduino/Arduino.java
@@ -9,6 +9,7 @@ import android.hardware.usb.UsbDevice;
 import android.hardware.usb.UsbDeviceConnection;
 import android.hardware.usb.UsbManager;
 import android.util.Log;
+import androidx.core.content.ContextCompat;
 
 import com.felhr.usbserial.UsbSerialDevice;
 import com.felhr.usbserial.UsbSerialInterface;
@@ -77,7 +78,7 @@ public class Arduino implements UsbSerialInterface.UsbReadCallback {
         intentFilter.addAction(UsbManager.ACTION_USB_DEVICE_ATTACHED);
         intentFilter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);
         intentFilter.addAction(ACTION_USB_DEVICE_PERMISSION);
-        context.registerReceiver(usbReceiver, intentFilter);
+        context.registerReceiver(usbReceiver, intentFilter,ContextCompat.RECEIVER_EXPORTED);
 
         lastArduinoAttached = getAttachedArduino();
         if (lastArduinoAttached != null && listener != null) {
@@ -94,7 +95,7 @@ public class Arduino implements UsbSerialInterface.UsbReadCallback {
         IntentFilter filter = new IntentFilter();
         filter.addAction(ACTION_USB_DEVICE_PERMISSION);
         filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);
-        context.registerReceiver(usbReceiver, filter);
+        context.registerReceiver(usbReceiver, filter,ContextCompat.RECEIVER_EXPORTED);
         usbManager.requestPermission(device, permissionIntent);
     }
 

--- a/arduino/src/main/java/me/aflak/arduino/Arduino.java
+++ b/arduino/src/main/java/me/aflak/arduino/Arduino.java
@@ -96,7 +96,7 @@ public class Arduino implements UsbSerialInterface.UsbReadCallback {
 
     @SuppressLint("NewApi")
     public void open(UsbDevice device) {
-        PendingIntent permissionIntent = PendingIntent.getBroadcast(context, 0, new Intent(ACTION_USB_DEVICE_PERMISSION), PendingIntent.FLAG_IMMUTABLE);
+        PendingIntent permissionIntent = PendingIntent.getBroadcast(context, 0, new Intent(ACTION_USB_DEVICE_PERMISSION), PendingIntent.FLAG_MUTABLE);
         IntentFilter filter = new IntentFilter();
         filter.addAction(ACTION_USB_DEVICE_PERMISSION);
         filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);


### PR DESCRIPTION
1. Added a pending mutability flag for Compile SDK 31+
2. Change device IDs to strings to accommodate non-Arduino boards
3. Added missing ContextCompat.RECEIVER_EXPORTED for Arduino broadcast receiver